### PR TITLE
Added the possibility to use this script from command line and fixed the creation error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # WinSCPSiteConfigurationToFileZilla
+## Introduction
 Due to software restrictions at work, I now have to use FileZilla instead of WinSCP.
 Given I have many sites, migrating them one by one is not viable.
 Therefore I have developed a small PHP script that will convert the WinSCP sites to FileZilla format.
@@ -7,3 +8,11 @@ The PHP page will output an upload form, on which you can send your WinSCP.ini f
 The script will do its thing, and propose you to download the matching sitemanager.xml file (in FileZilla for Windows, the xml file is located in %APPDATA%\FileZilla\).
 
 For the password recovery, I have reused the excellent tool developed by YuriMB : https://github.com/YuriMB/WinSCP-Password-Recovery, which I rendered less verbose, only to output the password.
+
+## Usage
+It's possible to use this script in your webbrowser if you have a webserver 
+installed. Just follow the instructions the page tell you.
+
+Alternatively you can use this script with php from command line.
+Example:\
+`php index.php filename=PATH_TO_YOUR_FILE\WinSCP.ini > OUTPUT_FILE.xml`

--- a/index.php
+++ b/index.php
@@ -1,237 +1,254 @@
 <?php
-	if(!isset($_FILES) || empty($_FILES)){
-?><!DOCTYPE html>
-<html>
+parse_str(implode('&', array_slice($argv, 1)), $_GET);
+
+if((!isset($_FILES) || empty($_FILES)) && !isset($_GET['fileName'])){
+?>
+<!DOCTYPE html>
+<html lang="en">
 <head><title>WinSCP configuration file converter</title></head>
-	<body>
-		<h1>Convert your WinSCP site manager data to Filezilla format</h1>
-		<form enctype="multipart/form-data" action="<?php echo $_SERVER['SCRIPT_NAME']?>" method="post">
-			<input type="hidden" name="MAX_FILE_SIZE" value="1048576" />
-			<label for="userfile">INI file : </label><input name="userfile" type="file" id="userfile" />
-			<input type="submit" />
-		</form>
-	</body>
+<body>
+    <h1>Convert your WinSCP site manager data to Filezilla format</h1>
+    <form enctype="multipart/form-data" action="<?php echo $_SERVER['SCRIPT_NAME'] ?>" method="post">
+        <input type="hidden" name="MAX_FILE_SIZE" value="1048576"/>
+        <label for="userfile">INI file : </label><input name="userfile" type="file" id="userfile"/>
+        <input type="submit"/>
+    </form>
+</body>
 </html>
-<?php 
-		die;
-	}
-	
-	$bErrorHasHappened = false;
-	
-	function processStructure($aStructureToParse, $oRootElement, $oParentElement){
-		if(is_array($aStructureToParse)){
-			foreach ($aStructureToParse as $sFolderName => $aSubStructure){
-				// site names are prefixed by "s|"
-				if(preg_match('/^s\|/', $sFolderName) == 1){
-					// this is a <Site>, only append it to the parent <Folder>
-					$sSiteName = preg_replace('/^s\|/', '', $sFolderName);
-					if(gettype($aSubStructure) == 'object'){
-						// This is a DOMElement, and not an array
-						$oParentElement->appendChild($aSubStructure);
-					}
-				} else{
-					// this is a <Folder>, create the <Folder> element, and parse the substructure
-					$oCurrentFolder = $oRootElement->createElement('Folder', $sFolderName);
-					$oParentElement->appendChild($oCurrentFolder);
-					processStructure($aSubStructure, $oRootElement, $oCurrentFolder);
-				}
-			}
-		}
-	}
-	
-	// open the file, filter out non session-related data
-	$handle = fopen($_FILES['userfile']['tmp_name'], "r");
-	$sINIFile = '';
-	if ($handle) {
-		$bKeepSection = true;
-		while (($line = fgets($handle)) !== false) {
-			if (preg_match('/^\[/', $line)){
-				// new section ; by default do not keep the following lines except it is session data
-				if(preg_match('/^\[Sessions\\\\(.*)\\](\\s*)$/', $line, $aMatches)){
-					$bKeepSection = true;
-					// As mentioned in http://php.net/manual/en/function.parse-ini-string.php, 
-					// some exotic characters in the section name can lead to errors 
-					// while reading the file. Uncomment array keys if you have read errors.
-					$aRemoveForbiddenSectionChars = Array(
-						'?' => '',
-						// '{' => '',
-						// '}' => '',
-						'|' => '',
-						'&' => '',
-						'~' => '',
-						'!' => '',
-						'[' => '',
-						// '(' => '',
-						// ')' => '',
-						'^' => '',
-						']' => '',
-					);
-					$line = '[Sessions\\' . strtr($aMatches[1], $aRemoveForbiddenSectionChars) . ']' . $aMatches[2];
-					$sINIFile .= $line;
-				}else{
-					$bKeepSection = false;
-				}
-			}else{
-				// process the line read. If it is site data, keep it.
-				if($bKeepSection){
-					$sINIFile .= $line;
-				}
-			}
-		}
+<?php
+die;
+}
 
-		fclose($handle);
-	}
-	
-	$aINIFile = parse_ini_string($sINIFile, true, INI_SCANNER_RAW);
-	
-	$aDirectoryStructure = array();
+$bErrorHasHappened = false;
+$sErrorToDisplay = '';
 
-	$oDoc = new DomDocument("1.0", "UTF-8");
-	$oRootNode = $oDoc->createElement('FileZilla3');
-	$oDoc->appendChild($oRootNode);
-	$oServers = $oDoc->createElement('Servers');
-	$oRootNode->appendChild($oServers);
-	$oDoc->preserveWhiteSpace = false;
-    $oDoc->formatOutput = true;
-    $oDoc->standalone = true;
-	
-	if(!is_array($aINIFile) || empty($aINIFile)){
-		$bErrorHasHappened = true;
-		$sErrorToDisplay = "The attempt to read the .ini file failed.";
-	}else{
-		ksort($aINIFile);
-		foreach ($aINIFile as $sSessionName => $aSessionConf){
-			// 1 create structure from the session name
-			$sSessionName = str_replace('Sessions\\','', $sSessionName);
-			$aFoldersStructure = explode('/', $sSessionName);
-			$aFoldersToCreate = array_splice($aFoldersStructure, 0, count($aFoldersStructure)-1);
-			$sSessionLabel = urldecode($aFoldersStructure[count($aFoldersStructure) -1 ]);
-			
-			// If the HostName value is not found, do not add the site.
-			if(!isset( $aSessionConf['HostName'])){
-				continue;
-			}
-			$sHostName = $aSessionConf['HostName'];
-			
-			// 2 export conf, in the right structure
-			$oServer = $oDoc->createElement('Server', $sSessionLabel);
-			$oNodeToAdd = $oDoc->createElement('Host', $sHostName);
-			$oServer->appendChild($oNodeToAdd);
-			
-			// Protocol 0 = FTP
-			// Protocol 1 = SFTP
-			$sProtocol = 1;	// by default, if the protocol is not set in WinSCP, it is SFTP
-			if (isset($aSessionConf['FSProtocol']) && $aSessionConf['FSProtocol'] == 5){
-				$sProtocol = "0";
-			}
-			$oNodeToAdd = $oDoc->createElement('Protocol', $sProtocol);
-			$oServer->appendChild($oNodeToAdd);
-			
-			if(array_key_exists('UserName', $aSessionConf)){
-				$sUserName = $aSessionConf['UserName'];
-			}else{
-				$sUserName = '';
-			}
-			if(array_key_exists('Password', $aSessionConf)){
-				$sCurrentPassword = $aSessionConf['Password'];
-			}else{
-				$sCurrentPassword = '';
-			}
-			$oNodeToAdd = $oDoc->createElement('User', $sUserName);
-			$oServer->appendChild($oNodeToAdd);
-			
-			$sPassword = base64_encode(exec('/usr/bin/java -jar ' .  __DIR__ . '/WinSCPPasswordDecrypt.jar "' . $sHostName . '" "' . $sUserName . '" "' . $sCurrentPassword . '"'));
-			$oPass = $oDoc->createElement('Pass', $sPassword);
-			$oPassEncoding = $oDoc->createAttribute('encoding');
-			$oPassEncoding->value = 'base64';
-			$oPass->appendChild($oPassEncoding);
-			$oServer->appendChild($oPass);
-			
-			if(array_key_exists('LocalDirectory', $aSessionConf)){
-				$oNodeToAdd = $oDoc->createElement('LocalDir', urldecode($aSessionConf['LocalDirectory']));
-			}else{
-				$oNodeToAdd = $oDoc->createElement('LocalDir', '');
-			}
-			$oServer->appendChild($oNodeToAdd);
-
-			if(array_key_exists('RemoteDirectory', $aSessionConf)){
-				$aRemoteDir = explode('/',urldecode($aSessionConf['RemoteDirectory']));
-				$sProcessedRemoteDir = '1';
-				foreach ($aRemoteDir as $sDirectory){
-					$sProcessedRemoteDir .= ' ' . strlen($sDirectory);
-					if($sDirectory != ''){
-						$sProcessedRemoteDir .= ' ' . $sDirectory;
-					}
-				}
-			}else{
-				$sProcessedRemoteDir = '';
-			}
-			$oNodeToAdd = $oDoc->createElement('RemoteDir', $sProcessedRemoteDir);
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('Port', isset($aSessionConf['PortNumber']) ? $aSessionConf['PortNumber'] : 22);
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('Type', 0);
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('Logontype', 1);
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('TimezoneOffset', 0);
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('PasvMode', 'MODE_DEFAULT');
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('MaximumMultipleConnections', 0);
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('EncodingType', 'Auto');
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('BypassProxy', 0);
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('SyncBrowsing', 0);
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('Comments');
-			$oServer->appendChild($oNodeToAdd);
-			$oNodeToAdd = $oDoc->createElement('Name', $sSessionLabel);
-			$oServer->appendChild($oNodeToAdd);
-			
-			// 3 from the last directory in the structure, "stack" directories on onto another
-			$aTempStructure = Array();
-            if (count($aFoldersToCreate) > 1){
-                for($iCptElements = count($aFoldersToCreate) - 1; $iCptElements >= 0; $iCptElements --){
-                    if($iCptElements == count($aFoldersToCreate) - 1){
-                        $aTempStructure = Array (
-                            $aFoldersToCreate[$iCptElements] => Array(
-                                 's|' . $sSessionLabel => $oServer
-                            )
-                        );
-                    }else{
-                        $aTempStructure = Array ($aFoldersToCreate[$iCptElements] => $aTempStructure);
-                    }
+function processStructure($aStructureToParse, $oRootElement, $oParentElement)
+{
+    if (is_array($aStructureToParse)) {
+        foreach ($aStructureToParse as $sFolderName => $aSubStructure) {
+            // site names are prefixed by "s|"
+            if (preg_match('/^s\|/', $sFolderName) === 1) {
+                // this is a <Site>, only append it to the parent <Folder>
+                $sSiteName = preg_replace('/^s\|/', '', $sFolderName);
+                if (gettype($aSubStructure) === 'object') {
+                    // This is a DOMElement, and not an array
+                    $oParentElement->appendChild($aSubStructure);
                 }
-            }else{
-                // handle the sites not stored into a "folder"
-                $aTempStructure = Array('s|' . $sSessionLabel => $oServer);
+            } else {
+                // this is a <Folder>, create the <Folder> element, and parse the substructure
+                $oCurrentFolder = $oRootElement->createElement('Folder', $sFolderName);
+                $oParentElement->appendChild($oCurrentFolder);
+                processStructure($aSubStructure, $oRootElement, $oCurrentFolder);
             }
+        }
+    }
+}
 
-			// add the directory structure to the global directory structure
-			$aDirectoryStructure = array_merge_recursive($aDirectoryStructure, $aTempStructure);
-		 	$oDoc->appendChild($oServer);
+// open the file, filter out non session-related data
+if (isset($_GET['fileName'])) {
+    $fileName = $_GET['fileName'];
+} else {
+    $fileName = $_FILES['userfile']['tmp_name'];
+}
 
-		}
-		
-		// 4 within $aDirectoryStructure, there is the folder structure, along with the XML nodes.
-		// Now, remains to create <folder> nodes for each level of the array, then add the DOM element present in it.
-		processStructure($aDirectoryStructure, $oDoc, $oServers);
+$handle   = fopen($fileName, "r");
+$sINIFile = '';
+if ($handle) {
+    $bKeepSection = true;
+    while (($line = fgets($handle)) !== false) {
+        if (preg_match('/^\[/', $line)) {
+            // new section ; by default do not keep the following lines except it is session data
+            if (preg_match('/^\[Sessions\\\\(.*)\\](\\s*)$/', $line, $aMatches)) {
+                $bKeepSection = true;
+                // As mentioned in http://php.net/manual/en/function.parse-ini-string.php,
+                // some exotic characters in the section name can lead to errors
+                // while reading the file. Uncomment array keys if you have read errors.
+                $aRemoveForbiddenSectionChars = array(
+                    '?' => '',
+                    // '{' => '',
+                    // '}' => '',
+                    '|' => '',
+                    '&' => '',
+                    '~' => '',
+                    '!' => '',
+                    '[' => '',
+                    // '(' => '',
+                    // ')' => '',
+                    '^' => '',
+                    ']' => '',
+                );
+                $line                         = '[Sessions\\' . strtr($aMatches[1],
+                        $aRemoveForbiddenSectionChars) . ']' . $aMatches[2];
+                $sINIFile                     .= $line;
+            } else {
+                $bKeepSection = false;
+            }
+        } else {
+            // process the line read. If it is site data, keep it.
+            if ($bKeepSection) {
+                $sINIFile .= $line;
+            }
+        }
+    }
+    
+    fclose($handle);
+}
 
-	}
-	
-	if (!$bErrorHasHappened){
-		header("Cache-Control: public");
-		header("Content-Description: File Transfer");
-		header("Content-Disposition: attachment; filename=sitemanager.xml");
-		header("Content-Type: application/octet-stream; "); 
-		header("Content-Transfer-Encoding: binary");
-		echo $oDoc->saveXML();
-	}else{
-		echo '<span style="color:red;">' . $sErrorToDisplay . '</span>';
-	}
-	
-	unlink($_FILES['userfile']['tmp_name']);
+$aINIFile = parse_ini_string($sINIFile, true, INI_SCANNER_RAW);
+
+$aDirectoryStructure = array();
+
+$oDoc      = new DomDocument('1.0', 'UTF-8');
+$oRootNode = $oDoc->createElement('FileZilla3');
+$oDoc->appendChild($oRootNode);
+$oServers = $oDoc->createElement('Servers');
+$oRootNode->appendChild($oServers);
+$oDoc->preserveWhiteSpace = false;
+$oDoc->formatOutput       = true;
+$oDoc->standalone         = true;
+
+if (!is_array($aINIFile) || empty($aINIFile)) {
+    $bErrorHasHappened = true;
+    $sErrorToDisplay   = 'The attempt to read the .ini file failed.';
+} else {
+    ksort($aINIFile);
+    foreach ($aINIFile as $sSessionName => $aSessionConf) {
+        // 1 create structure from the session name
+        $sSessionName      = str_replace('Sessions\\', '', $sSessionName);
+        $aFoldersStructure = explode('/', $sSessionName);
+        $aFoldersToCreate  = array_splice($aFoldersStructure, 0, count($aFoldersStructure) - 1);
+        $sSessionLabel     = urldecode($aFoldersStructure[count($aFoldersStructure) - 1]);
+        
+        // If the HostName value is not found, do not add the site.
+        if (!isset($aSessionConf['HostName'])) {
+            continue;
+        }
+        $sHostName = $aSessionConf['HostName'];
+        
+        // 2 export conf, in the right structure
+        $oServer    = $oDoc->createElement('Server', $sSessionLabel);
+        $oNodeToAdd = $oDoc->createElement('Host', $sHostName);
+        $oServer->appendChild($oNodeToAdd);
+        
+        // Protocol 0 = FTP
+        // Protocol 1 = SFTP
+        $sProtocol = 1;    // by default, if the protocol is not set in WinSCP, it is SFTP
+        if (isset($aSessionConf['FSProtocol']) && $aSessionConf['FSProtocol'] == 5) {
+            $sProtocol = '0';
+        }
+        $oNodeToAdd = $oDoc->createElement('Protocol', $sProtocol);
+        $oServer->appendChild($oNodeToAdd);
+        
+        if (array_key_exists('UserName', $aSessionConf)) {
+            $sUserName = $aSessionConf['UserName'];
+        } else {
+            $sUserName = '';
+        }
+        if (array_key_exists('Password', $aSessionConf)) {
+            $sCurrentPassword = $aSessionConf['Password'];
+        } else {
+            $sCurrentPassword = '';
+        }
+        $oNodeToAdd = $oDoc->createElement('User', $sUserName);
+        $oServer->appendChild($oNodeToAdd);
+        
+        $javaEncryption = '/usr/bin/java -jar ' . __DIR__ . '/WinSCPPasswordDecrypt.jar ' . $sHostName . ' ' . $sUserName . ' ' . $sCurrentPassword;
+        
+        $sPassword            = base64_encode(exec($javaEncryption));
+        $oPass                = $oDoc->createElement('Pass', $sPassword);
+        $oPassEncoding        = $oDoc->createAttribute('encoding');
+        $oPassEncoding->value = 'base64';
+        $oPass->appendChild($oPassEncoding);
+        $oServer->appendChild($oPass);
+        
+        if (array_key_exists('LocalDirectory', $aSessionConf)) {
+            $oNodeToAdd = $oDoc->createElement('LocalDir', urldecode($aSessionConf['LocalDirectory']));
+        } else {
+            $oNodeToAdd = $oDoc->createElement('LocalDir', '');
+        }
+        $oServer->appendChild($oNodeToAdd);
+        
+        if (array_key_exists('RemoteDirectory', $aSessionConf)) {
+            $aRemoteDir          = explode('/', urldecode($aSessionConf['RemoteDirectory']));
+            $sProcessedRemoteDir = '1';
+            foreach ($aRemoteDir as $sDirectory) {
+                $sProcessedRemoteDir .= ' ' . strlen($sDirectory);
+                if ($sDirectory !== '') {
+                    $sProcessedRemoteDir .= ' ' . $sDirectory;
+                }
+            }
+        } else {
+            $sProcessedRemoteDir = '';
+        }
+        $oNodeToAdd = $oDoc->createElement('RemoteDir', $sProcessedRemoteDir);
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('Port',
+            isset($aSessionConf['PortNumber']) ? $aSessionConf['PortNumber'] : 22);
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('Type', 0);
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('Logontype', 1);
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('TimezoneOffset', 0);
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('PasvMode', 'MODE_DEFAULT');
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('MaximumMultipleConnections', 0);
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('EncodingType', 'Auto');
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('BypassProxy', 0);
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('SyncBrowsing', 0);
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('Comments');
+        $oServer->appendChild($oNodeToAdd);
+        $oNodeToAdd = $oDoc->createElement('Name', $sSessionLabel);
+        $oServer->appendChild($oNodeToAdd);
+        
+        // 3 from the last directory in the structure, "stack" directories on onto another
+        $aTempStructure = array();
+        if (count($aFoldersToCreate) > 1) {
+            for ($iCptElements = count($aFoldersToCreate) - 1; $iCptElements >= 0; $iCptElements--) {
+                if ($iCptElements === count($aFoldersToCreate) - 1) {
+                    $aTempStructure = array(
+                        $aFoldersToCreate[$iCptElements] => array(
+                            's|' . $sSessionLabel => $oServer
+                        )
+                    );
+                } else {
+                    $aTempStructure = array($aFoldersToCreate[$iCptElements] => $aTempStructure);
+                }
+            }
+        } else {
+            // handle the sites not stored into a "folder"
+            $aTempStructure = array('s|' . $sSessionLabel => $oServer);
+        }
+        
+        // add the directory structure to the global directory structure
+        $aDirectoryStructure = array_merge_recursive($aDirectoryStructure, $aTempStructure);
+        $oDoc->appendChild($oServer);
+        
+    }
+    
+    // 4 within $aDirectoryStructure, there is the folder structure, along with the XML nodes.
+    // Now, remains to create <folder> nodes for each level of the array, then add the DOM element present in it.
+    processStructure($aDirectoryStructure, $oDoc, $oServers);
+    
+}
+
+if (!$bErrorHasHappened) {
+    header('Cache-Control: public');
+    header('Content-Description: File Transfer');
+    header('Content-Disposition: attachment; filename=sitemanager.xml');
+    header('Content-Type: application/octet-stream; ');
+    header('Content-Transfer-Encoding: binary');
+    echo $oDoc->saveXML();
+} else {
+    echo '<span style="color:red;">' . $sErrorToDisplay . '</span>';
+}
+
+if (isset($_FILES['userfile']['tmp_name']) && file_exists($_FILES['userfile']['tmp_name'])) {
+    unlink($_FILES['userfile']['tmp_name']);
+}
 ?>

--- a/index.php
+++ b/index.php
@@ -126,7 +126,7 @@ if (!is_array($aINIFile) || empty($aINIFile)) {
         $sHostName = $aSessionConf['HostName'];
         
         // 2 export conf, in the right structure
-        $oServer    = $oDoc->createElement('Server', $sSessionLabel);
+        $oServer    = $oDoc->createElement('Server');
         $oNodeToAdd = $oDoc->createElement('Host', $sHostName);
         $oServer->appendChild($oNodeToAdd);
         

--- a/index.php
+++ b/index.php
@@ -208,16 +208,20 @@ if (!is_array($aINIFile) || empty($aINIFile)) {
         
         // 3 from the last directory in the structure, "stack" directories on onto another
         $aTempStructure = array();
-        if (count($aFoldersToCreate) > 1) {
-            for ($iCptElements = count($aFoldersToCreate) - 1; $iCptElements >= 0; $iCptElements--) {
-                if ($iCptElements === count($aFoldersToCreate) - 1) {
+        
+        if (count($aFoldersToCreate) > 0) {
+            $aFoldersToCreateCount = count($aFoldersToCreate) - 1;
+            for ($iCptElements = $aFoldersToCreateCount; $iCptElements >= 0; $iCptElements--) {
+                $sFolderName = urldecode($aFoldersToCreate[$iCptElements]);
+                
+                if ($iCptElements === $aFoldersToCreateCount) {
                     $aTempStructure = array(
-                        $aFoldersToCreate[$iCptElements] => array(
+                        $sFolderName => array(
                             's|' . $sSessionLabel => $oServer
                         )
                     );
                 } else {
-                    $aTempStructure = array($aFoldersToCreate[$iCptElements] => $aTempStructure);
+                    $aTempStructure = array($sFolderName => $aTempStructure);
                 }
             }
         } else {


### PR DESCRIPTION
Now it's possible to easily use the index.php from command line like this:

`php index.php filename=PATH_TO_YOUR_FILE\WinSCP.ini > OUTPUT_FILE.xml`

I updated the readme to explain the usage, too

There was an error creating the folder structure. The check was `count($aFoldersToCreate) > 1` instead of `> 0` and the urldecode function was missing.

The name of the session/server was defined twice in the structure which is unnecessary for fileZilla. I removed this.